### PR TITLE
Add setHTML method to EtherpadLiteClient

### DIFF
--- a/src/py_etherpad.py
+++ b/src/py_etherpad.py
@@ -187,7 +187,7 @@ class EtherpadLiteClient:
             "text": text
         })
 
-    def setHTML(self, padID, html):
+    def setHtml(self, padID, html):
         """sets the text of a pad from html"""
         return self.call("setHTML", {
             "padID": padID,

--- a/src/test/test_py_etherpad.py
+++ b/src/test/test_py_etherpad.py
@@ -29,7 +29,8 @@ class TestEtherpadLiteClient(unittest.TestCase):
 
         #Create and remove pad
         print self.ep_client.createPad('htmlpad')
-        print self.ep_client.setHTML('htmlpad', content)
+        print self.ep_client.setHtml('htmlpad', content)
+        print self.ep_client.getHtml('htmlpad')
         print self.ep_client.deletePad('htmlpad')
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following Pita/etherpad-lite#204 there's now a setHTML method available in the EtherpadLite API. This branch adds a method to call setHTML, and a unittest case to test the method.
