### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 This python api enables easy interaction with the Etherpad Lite API.  Etherpad Lite is a collaborative editor provided by the Etherpad Foundation.  http://etherpad.org
 
-#1 Installation
+# 1 Installation
 
 To install py_etherpad using PIP, add the following line to your requirements.txt file:
 
     -e git+git://github.com/devjones/PyEtherpadLite.git#egg=PyEtherpadLite
 
-#2 Preparation
+# 2 Preparation
 
 If you are using a self hosted Etherpad Lite server, you will need to specify an API Key after installation before using the API.  (See https://github.com/Pita/etherpad-lite for installation details).
 
@@ -16,7 +16,7 @@ Your secret api key should be placed in the base installation (etherpad-client f
 
 Once you have created the APIKEY.txt file, you will need to edit the py_etherpad.py wrapper to set your API key. Edit the 'apiKey' variable and set it to the same key as defined in your APIKEY.txt file.
 
-#3 Basic usage
+# 3 Basic usage
 
     from py_etherpad import EtherpadLiteClient
     myPad = EtherpadLiteClient('EtherpadFTW','http://beta.etherpad.org/api')
@@ -24,13 +24,13 @@ Once you have created the APIKEY.txt file, you will need to edit the py_etherpad
     #Change the text of the etherpad
     myPad.setText('testPad','New text from the python wrapper!')
 
-#4 More details
+# 4 More details
 
 See the py_etherpad.py file for further details on the methods and parameters available for the API
 
-#5 License
+# 5 License
 
 Apache License
 
-#6 Credit
+# 6 Credit
 This python client was inspired by TomNomNom's php client which can be found at: https://github.com/TomNomNom/etherpad-lite-client


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
